### PR TITLE
Release 0.1.1: update supported Python versions and dependency ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Flakepipe
 
 [![PyPI](https://img.shields.io/pypi/v/flakepipe)](https://pypi.org/project/flakepipe/)
-[![Python](https://img.shields.io/pypi/pyversions/flakepipe)](https://pypi.org/project/flakepipe/)
+[![Python](https://img.shields.io/badge/Python-3.8%20|%203.9%20|%203.10%20|%203.11-blue)](https://pypi.org/project/flakepipe/)
 [![License](https://img.shields.io/github/license/geeone/flakepipe)](LICENSE)
 [![Build Status](https://github.com/geeone/flakepipe/actions/workflows/build.yml/badge.svg)](https://github.com/geeone/flakepipe/actions/workflows/build.yml)
 [![Codecov](https://codecov.io/gh/geeone/flakepipe/branch/main/graph/badge.svg)](https://codecov.io/gh/geeone/flakepipe)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(path, "README.md"), "r", encoding="utf-8") as f:
 
 setup(
     name='flakepipe',
-    version='0.1.0',
+    version='0.1.1',
     author='Sergei Denisenko',
     author_email='your.email@example.com',
     description='Reusable module for uploading datasets to Snowflake via stage',
@@ -33,7 +33,7 @@ setup(
         'Operating System :: OS Independent',
     ],
     license='MIT',
-    python_requires='>=3.8',
+    python_requires='>=3.8,<3.12',
     install_requires=requirements,
     keywords='snowflake upload ETL csv stage data',
 )


### PR DESCRIPTION
- Bump version to 0.1.1
- Set python_requires='>=3.8,<3.12'
- Restrict pandas to >=1.4.0,<2.1
- Restrict numpy to >=1.21.0,<1.26.0
- Add classifiers for supported Python versions